### PR TITLE
Fix return types, type declarations, parameter types and add setQueue…

### DIFF
--- a/src/Resque.php
+++ b/src/Resque.php
@@ -61,6 +61,11 @@ class Resque
         return static::$queue;
     }
 
+    public static function setQueue(Queue $queue): void
+    {
+        static::$queue = $queue;
+    }
+
     /**
      * Dynamically pass calls to the default connection.
      *

--- a/src/Resque/Job.php
+++ b/src/Resque/Job.php
@@ -104,14 +104,14 @@ class Job
     /**
      * Create a new job and save it to the specified queue.
      *
-     * @param string          $queue  The name of the queue to place the job in
-     * @param string|callable $class  The name of the class that contains the code to execute the job
-     * @param array           $data   Any optional arguments that should be passed when the job is executed
-     * @param int             $run_at Unix timestamp of when to run the job to delay execution
+     * @param string            $queue  The name of the queue to place the job in
+     * @param string|callable   $class  The name of the class that contains the code to execute the job
+     * @param array|null        $data   Any optional arguments that should be passed when the job is executed
+     * @param int               $run_at Unix timestamp of when to run the job to delay execution
      *
-     * @return Job
+     * @return Job|bool
      */
-    public static function create(string $queue, $class, ?array $data = null, int $run_at = 0): Job
+    public static function create(string $queue, $class, ?array $data = null, int $run_at = 0)
     {
         $id = static::createId($queue, $class, $data, $run_at);
 
@@ -155,9 +155,9 @@ class Job
      *
      * @param string $id The job id
      *
-     * @return static
+     * @return static|null
      */
-    public static function load(string $id): self
+    public static function load(string $id): ?self
     {
         $packet = Redis::instance()->hgetall(self::redisKey($id));
 

--- a/src/Resque/Logger/Handler/Connector/AbstractConnector.php
+++ b/src/Resque/Logger/Handler/Connector/AbstractConnector.php
@@ -33,7 +33,7 @@ abstract class AbstractConnector implements ConnectorInterface
      * @param OutputInterface $output
      * @param array           $args
      *
-     * @return StripProcessor
+     * @return StripFormatProcessor
      */
     public function processor(Command $command, InputInterface $input, OutputInterface $output, array $args)
     {

--- a/src/Resque/Worker.php
+++ b/src/Resque/Worker.php
@@ -172,9 +172,9 @@ class Worker
      * @param string $id     Worker id
      * @param Logger $logger Logger for the worker to use
      *
-     * @return Worker
+     * @return Worker|bool
      */
-    public static function fromId(string $id, ?Logger $logger = null): Worker
+    public static function fromId(string $id, ?Logger $logger = null)
     {
         if (!$id or !count($packet = Redis::instance()->hgetall(self::redisKey($id)))) {
             return false;
@@ -970,9 +970,9 @@ class Worker
     /**
      * Set the worker queues
      *
-     * @param string $queues Queues for worker to watch
+     * @param array $queues Queues for worker to watch
      */
-    public function setQueues(string $queues): void
+    public function setQueues(array $queues): void
     {
         if ($this->status != self::STATUS_NEW) {
             throw new \RuntimeException('Cannot set worker queues after worker has started working');

--- a/test/speed/autoload.php
+++ b/test/speed/autoload.php
@@ -9,6 +9,7 @@
  * file that was distributed with this source code.
  */
 
+use Monolog\Handler\StreamHandler;
 use Resque\Event;
 use Resque\Logger;
 
@@ -20,6 +21,8 @@ class TestJob
         // Don't do anything
     }
 }
+
+$logger = new Logger([new StreamHandler('php://stdout')]);
 
 // Lets record the forking time
 Event::listen([Event::WORKER_FORK, Event::WORKER_FORK_CHILD], function ($event, $job) use ($logger): void {


### PR DESCRIPTION
Fixes: https://github.com/mjphaynes/php-resque/issues/114
Fixes the wrong return types and parameter types.
Added setQueue method for Resque.
Fixed missing $logger declaration.